### PR TITLE
Waits for esp_rmaker_work_queue being stopped on deinit.

### DIFF
--- a/src/work_queue.c
+++ b/src/work_queue.c
@@ -97,6 +97,15 @@ esp_err_t esp_rmaker_work_queue_init(void)
 
 esp_err_t esp_rmaker_work_queue_deinit(void)
 {
+    if (queue_state != WORK_QUEUE_STATE_STOP_REQUESTED) {
+        esp_rmaker_work_queue_stop();
+    }
+
+    while (queue_state == WORK_QUEUE_STATE_STOP_REQUESTED) {
+        ESP_LOGI(TAG, "Waiting for esp_rmaker_work_queue being stopped...");
+        vTaskDelay(2000 / portTICK_PERIOD_MS);
+    }
+
     if (queue_state == WORK_QUEUE_STATE_DEINIT) {
         return ESP_OK;
     } else if (queue_state != WORK_QUEUE_STATE_INIT_DONE) {
@@ -107,6 +116,7 @@ esp_err_t esp_rmaker_work_queue_deinit(void)
         work_queue = NULL;
         queue_state = WORK_QUEUE_STATE_DEINIT;
     }
+    ESP_LOGI(TAG, "esp_rmaker_work_queue was successfully deinitialized");
     return ESP_OK;
 }
 


### PR DESCRIPTION
When the function esp_rmaker_work_queue_stop is called it sets the
queue state as 'WORK_QUEUE_STATE_STOP_REQUESTED', however the
esp_rmaker_work_queue_task only sets the 'WORK_QUEUE_STATE_INIT_DONE'
status after the function esp_rmaker_handle_work_queue returns.
This commit is necessary to implement the
esp_insights_unregister_periodic_handler.