### PR TITLE
Fix issue when MQTT_SEND_USERNAME is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(srcs "src/work_queue.c" "src/factory.c" "src/time.c" "src/timezone.c" "src/utils.c" "src/create_APN3_PPI_string.c" "src/cmd_resp.c")
+set(srcs "src/work_queue.c" "src/factory.c" "src/time.c" "src/timezone.c" "src/utils.c" "src/cmd_resp.c")
 set(priv_req "mqtt" "nvs_flash")
 
 # from IDF version 5.0, we need to explicitly specify requirements
@@ -9,6 +9,9 @@ endif()
 #if(CONFIG_ESP_RMAKER_LIB_ESP_MQTT)
     list(APPEND srcs "src/esp-mqtt/esp-mqtt-glue.c")
 #endif()
+if(CONFIG_ESP_RMAKER_MQTT_SEND_USERNAME)
+    list(APPEND srcs "src/create_APN3_PPI_string.c")
+endif()
 
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS "include"


### PR DESCRIPTION
This patch fix the following compilation issue when we set CONFIG_ESP_RMAKER_MQTT_SEND_USERNAME=n in sdkconfig:
```
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c: In function 'platform_get_product_name':
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c:34:33: error: 'CONFIG_ESP_RMAKER_MQTT_PRODUCT_NAME' undeclared (first use in this function); did you mean 'CONFIG_ESP_RMAKER_MQTT_PORT_8883'?
   34 | #define PPI_PRODUCT_NAME        CONFIG_ESP_RMAKER_MQTT_PRODUCT_NAME
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c:34:33: note: in definition of macro 'PPI_PRODUCT_NAME'
   34 | #define PPI_PRODUCT_NAME        CONFIG_ESP_RMAKER_MQTT_PRODUCT_NAME
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c:34:33: note: each undeclared identifier is reported only once for each function it appears in
   34 | #define PPI_PRODUCT_NAME        CONFIG_ESP_RMAKER_MQTT_PRODUCT_NAME
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c:34:33: note: in definition of macro 'PPI_PRODUCT_NAME'
   34 | #define PPI_PRODUCT_NAME        CONFIG_ESP_RMAKER_MQTT_PRODUCT_NAME
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c: In function 'platform_get_product_version':
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c:35:33: error: 'CONFIG_ESP_RMAKER_MQTT_PRODUCT_VERSION' undeclared (first use in this function); did you mean 'CONFIG_ESP_RMAKER_MQTT_PORT_8883'?
   35 | #define PPI_PRODUCT_VERSION     CONFIG_ESP_RMAKER_MQTT_PRODUCT_VERSION
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c:35:33: note: in definition of macro 'PPI_PRODUCT_VERSION'
   35 | #define PPI_PRODUCT_VERSION     CONFIG_ESP_RMAKER_MQTT_PRODUCT_VERSION
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c: In function 'platform_get_silicon_sku_code':
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c:33:33: error: 'CONFIG_ESP_RMAKER_MQTT_PRODUCT_SKU' undeclared (first use in this function); did you mean 'CONFIG_ESP_RMAKER_MQTT_PORT_8883'?
   33 | #define PPI_SILICON_SKU_CODE    CONFIG_ESP_RMAKER_MQTT_PRODUCT_SKU
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c:33:33: note: in definition of macro 'PPI_SILICON_SKU_CODE'
   33 | #define PPI_SILICON_SKU_CODE    CONFIG_ESP_RMAKER_MQTT_PRODUCT_SKU
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c: In function 'platform_get_product_name':
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c:53:1: error: control reaches end of non-void function [-Werror=return-type]
   53 | }
      | ^
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c: In function 'platform_get_product_version':
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c:81:1: error: control reaches end of non-void function [-Werror=return-type]
   81 | }
      | ^
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c: In function 'platform_get_silicon_sku_code':
/home/bruno/dev/esp/c3/esp-rainmaker/components/rmaker_common/src/create_APN3_PPI_string.c:91:1: error: control reaches end of non-void function [-Werror=return-type]
   91 | }
      | ^
cc1: some warnings being treated as errors
ninja: build stopped: subcommand failed.
```