### PR TITLE
Replace deprecated component upload action

### DIFF
--- a/.github/workflows/upload_components.yml
+++ b/.github/workflows/upload_components.yml
@@ -1,4 +1,4 @@
-name: Push components to Espressif Component Service
+name: Push components to Espressif Component Registry
 
 on:
   push:
@@ -9,12 +9,12 @@ jobs:
   upload_components:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
         with:
           submodules: "recursive"
 
-      - name: Upload components to component service
-        uses: espressif/github-actions/upload_components@master
+      - name: Upload components to component registry
+        uses: espressif/upload-components-ci-action@v1
         with:
           namespace: "espressif"
           name: "rmaker_common"


### PR DESCRIPTION
Use `espressif/upload-components-ci-action@v1` instead of deprecated one